### PR TITLE
[Refactor] Remove wildcard `use` statements

### DIFF
--- a/crates/ast/src/expr/mod.rs
+++ b/crates/ast/src/expr/mod.rs
@@ -61,26 +61,26 @@ impl Expr {
     }
 
     pub fn range(self) -> TextRange {
-        use Expr::*;
+        use Expr as E;
         match self {
-            ArrayLiteral(e) => e.range(),
-            Block(e) => e.range(),
-            Binary(e) => e.range(),
-            BoolLiteral(e) => e.range(),
-            Call(e) => e.range(),
-            FloatLiteral(e) => e.range(),
-            ForInLoop(e) => e.range(),
-            Function(e) => e.range(),
-            Ident(e) => e.range(),
-            If(e) => e.range(),
-            IntLiteral(e) => e.range(),
-            LetBinding(e) => e.range(),
-            Loop(e) => e.range(),
-            Paren(e) => e.range(),
-            Path(e) => e.range(),
-            Return(e) => e.range(),
-            StringLiteral(e) => e.range(),
-            Unary(e) => e.range(),
+            E::ArrayLiteral(e) => e.range(),
+            E::Block(e) => e.range(),
+            E::Binary(e) => e.range(),
+            E::BoolLiteral(e) => e.range(),
+            E::Call(e) => e.range(),
+            E::FloatLiteral(e) => e.range(),
+            E::ForInLoop(e) => e.range(),
+            E::Function(e) => e.range(),
+            E::Ident(e) => e.range(),
+            E::If(e) => e.range(),
+            E::IntLiteral(e) => e.range(),
+            E::LetBinding(e) => e.range(),
+            E::Loop(e) => e.range(),
+            E::Paren(e) => e.range(),
+            E::Path(e) => e.range(),
+            E::Return(e) => e.range(),
+            E::StringLiteral(e) => e.range(),
+            E::Unary(e) => e.range(),
         }
     }
 }
@@ -296,16 +296,16 @@ pub enum FunParam {
 
 impl FunParam {
     pub fn cast(node: SyntaxNode) -> Option<Self> {
-        use SyntaxKind::*;
+        use SyntaxKind as S;
 
         match node.kind() {
             // (aaa: A, bbb: B) ->
             //  ^^^^^^
-            ParenExprItem => Some(Self::WithType(node)),
+            S::ParenExprItem => Some(Self::WithType(node)),
 
             // aaa ->
             // ^^^
-            Path => Some(Self::WithoutType(node)),
+            // S::Path => Some(Self::WithoutType(node)),
 
             // (aaa) ->
             // ^^^^^

--- a/crates/ast/src/expr/type_expr.rs
+++ b/crates/ast/src/expr/type_expr.rs
@@ -45,19 +45,19 @@ impl TypeExpr {
     }
 
     pub fn range(&self) -> TextRange {
-        use TypeExpr::*;
+        use TypeExpr as T;
         match self {
             // Binary(e) => e.range(),
-            BoolLiteral(e) => e.range(),
-            Call(e) => e.range(),
-            FloatLiteral(e) => e.range(),
-            Function(e) => e.range(),
-            Ident(e) => e.range(),
-            IntLiteral(e) => e.range(),
-            Path(e) => e.range(),
+            T::BoolLiteral(e) => e.range(),
+            T::Call(e) => e.range(),
+            T::FloatLiteral(e) => e.range(),
+            T::Function(e) => e.range(),
+            T::Ident(e) => e.range(),
+            T::IntLiteral(e) => e.range(),
+            T::Path(e) => e.range(),
             // If(e) => e.range(),
             // Paren(e) => e.range(),
-            StringLiteral(e) => e.range(),
+            T::StringLiteral(e) => e.range(),
             // Unary(e) => e.range(),
         }
     }

--- a/crates/ast/src/tests.rs
+++ b/crates/ast/src/tests.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::{Expr, TypeExpr};
 
 /// Asserts that the provided `Option` is `Some`
 /// and returns the unwrapped value.

--- a/crates/hir/src/context.rs
+++ b/crates/hir/src/context.rs
@@ -179,24 +179,24 @@ impl<'a> Context<'a> {
     }
 
     pub(crate) fn lower_expr(&mut self, ast: Option<ast::Expr>) -> Idx<Expr> {
-        use ast::Expr::*;
+        use ast::Expr as E;
         let expr = if let Some(ast) = ast.clone() {
             match ast {
-                Binary(ast) => self.lower_binary(ast),
-                Block(ast) => self.lower_block(ast),
-                BoolLiteral(ast) => self.lower_bool_literal(ast),
-                Call(ast) => self.lower_call(ast),
-                FloatLiteral(ast) => self.lower_float_literal(ast),
-                Function(ast) => self.lower_function_expr(ast),
-                If(ast) => self.lower_if_expr(ast),
-                IntLiteral(ast) => self.lower_int_literal(ast),
-                LetBinding(ast) => self.lower_let_binding(ast),
-                Loop(ast) => self.lower_loop(ast),
-                Paren(ast) => return self.lower_expr(ast.expr()),
-                Path(ast) => self.lower_path(ast),
-                Return(ast) => self.lower_return_statement(ast),
-                StringLiteral(ast) => self.lower_string_literal(ast),
-                Unary(ast) => self.lower_unary(ast),
+                E::Binary(ast) => self.lower_binary(ast),
+                E::Block(ast) => self.lower_block(ast),
+                E::BoolLiteral(ast) => self.lower_bool_literal(ast),
+                E::Call(ast) => self.lower_call(ast),
+                E::FloatLiteral(ast) => self.lower_float_literal(ast),
+                E::Function(ast) => self.lower_function_expr(ast),
+                E::If(ast) => self.lower_if_expr(ast),
+                E::IntLiteral(ast) => self.lower_int_literal(ast),
+                E::LetBinding(ast) => self.lower_let_binding(ast),
+                E::Loop(ast) => self.lower_loop(ast),
+                E::Paren(ast) => return self.lower_expr(ast.expr()),
+                E::Path(ast) => self.lower_path(ast),
+                E::Return(ast) => self.lower_return_statement(ast),
+                E::StringLiteral(ast) => self.lower_string_literal(ast),
+                E::Unary(ast) => self.lower_unary(ast),
             }
         } else {
             Expr::Empty
@@ -426,18 +426,18 @@ impl<'a> Context<'a> {
 // Lowering functions - TypeExpr
 impl<'a> Context<'a> {
     fn lower_type_expr(&mut self, ast: Option<ast::TypeExpr>) -> Idx<TypeExpr> {
-        use ast::TypeExpr::*;
+        use ast::TypeExpr as T;
         if let Some(ast) = ast {
             let range = ast.range();
             let type_expr = match ast {
-                BoolLiteral(ast) => self.lower_type_bool_literal(ast),
-                FloatLiteral(ast) => self.lower_type_float_literal(ast),
-                IntLiteral(ast) => self.lower_type_int_literal(ast),
-                StringLiteral(ast) => self.lower_type_string_literal(ast),
+                T::BoolLiteral(ast) => self.lower_type_bool_literal(ast),
+                T::FloatLiteral(ast) => self.lower_type_float_literal(ast),
+                T::IntLiteral(ast) => self.lower_type_int_literal(ast),
+                T::StringLiteral(ast) => self.lower_type_string_literal(ast),
 
-                Function(_) => todo!(),
-                Path(ast) => self.lower_type_path(ast),
-                Call(ast) => self.lower_type_call(ast),
+                T::Function(_) => todo!(),
+                T::Path(ast) => self.lower_type_path(ast),
+                T::Call(ast) => self.lower_type_call(ast),
             };
             self.alloc_type_expr(type_expr, range)
         } else {

--- a/crates/hir/src/diagnostic.rs
+++ b/crates/hir/src/diagnostic.rs
@@ -153,23 +153,23 @@ pub enum TypeDiagnosticVariant {
 
 impl ContextDisplay for TypeDiagnosticVariant {
     fn display(&self, context: &Context) -> String {
-        use TypeDiagnosticVariant::*;
+        use TypeDiagnosticVariant as V;
         match self {
-            ArgsMismatch { expected, actual } => args_mismatch_message(*expected, *actual),
-            BinaryMismatch { op, lhs, rhs } => {
+            V::ArgsMismatch { expected, actual } => args_mismatch_message(*expected, *actual),
+            V::BinaryMismatch { op, lhs, rhs } => {
                 let lhs = context.borrow_type(*lhs);
                 let rhs = context.borrow_type(*rhs);
                 binary_mismatch_message(*op, lhs.display(context), rhs.display(context))
             }
-            CalleeNotFunction { actual } => todo!(),
-            CannotConvertIntoString { actual } => todo!(),
-            Empty { expr } => todo!(),
-            Incompatible { a, b } => todo!(),
-            NoOverloadFound { name } => todo!(),
-            TypeMismatch { expected, actual } => todo!(),
-            UndefinedFunction { name } => todo!(),
-            UnresolvedLocalRef { key } => todo!(),
-            UndefinedSymbol { name } => todo!(),
+            V::CalleeNotFunction { actual } => todo!(),
+            V::CannotConvertIntoString { actual } => todo!(),
+            V::Empty { expr } => todo!(),
+            V::Incompatible { a, b } => todo!(),
+            V::NoOverloadFound { name } => todo!(),
+            V::TypeMismatch { expected, actual } => todo!(),
+            V::UndefinedFunction { name } => todo!(),
+            V::UnresolvedVarRef { key } => todo!(),
+            V::UndefinedSymbol { name } => todo!(),
         }
     }
 }

--- a/crates/hir/src/expr/mod.rs
+++ b/crates/hir/src/expr/mod.rs
@@ -271,18 +271,18 @@ pub enum BinaryOp {
 
 impl fmt::Display for BinaryOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use BinaryOp::*;
+        use BinaryOp as O;
         match self {
-            Add => write!(f, "+"),
-            Sub => write!(f, "-"),
-            Mul => write!(f, "*"),
-            Div => write!(f, "/"),
-            Concat => write!(f, "++"),
-            Rem => write!(f, "%"),
-            Exp => write!(f, "^"),
-            Path => write!(f, "."),
-            Eq => write!(f, "=="),
-            Ne => write!(f, "!="),
+            O::Add => write!(f, "+"),
+            O::Sub => write!(f, "-"),
+            O::Mul => write!(f, "*"),
+            O::Div => write!(f, "/"),
+            O::Concat => write!(f, "++"),
+            O::Rem => write!(f, "%"),
+            O::Exp => write!(f, "^"),
+            O::Path => write!(f, "."),
+            O::Eq => write!(f, "=="),
+            O::Ne => write!(f, "!="),
         }
     }
 }

--- a/crates/hir/src/lowering_context.rs
+++ b/crates/hir/src/lowering_context.rs
@@ -212,27 +212,27 @@ impl Context {
     }
 
     pub(crate) fn lower_expr(&mut self, ast: Option<ast::Expr>) -> Idx<Expr> {
-        use ast::Expr::*;
+        use ast::Expr as E;
         let expr = if let Some(ast) = ast.clone() {
             match ast {
-                ArrayLiteral(ast) => self.lower_array_literal(ast),
-                Binary(ast) => self.lower_binary(ast),
-                Block(ast) => self.lower_block(ast),
-                BoolLiteral(ast) => self.lower_bool_literal(ast),
-                Call(ast) => self.lower_call(ast),
-                FloatLiteral(ast) => self.lower_float_literal(ast),
-                Function(ast) => self.lower_function_expr(ast),
-                ForInLoop(ast) => self.lower_for_in_loop(ast),
-                Ident(ast) => self.lower_name_ref(&ast.as_string()),
-                If(ast) => self.lower_if_expr(ast),
-                IntLiteral(ast) => self.lower_int_literal(ast),
-                LetBinding(ast) => self.lower_let_binding(ast),
-                Loop(ast) => self.lower_loop(ast),
-                Paren(ast) => return self.lower_expr(ast.expr()),
-                Path(ast) => self.lower_path(ast),
-                Return(ast) => self.lower_return_statement(ast),
-                StringLiteral(ast) => self.lower_string_literal(ast),
-                Unary(ast) => self.lower_unary(ast),
+                E::ArrayLiteral(ast) => self.lower_array_literal(ast),
+                E::Binary(ast) => self.lower_binary(ast),
+                E::Block(ast) => self.lower_block(ast),
+                E::BoolLiteral(ast) => self.lower_bool_literal(ast),
+                E::Call(ast) => self.lower_call(ast),
+                E::FloatLiteral(ast) => self.lower_float_literal(ast),
+                E::Function(ast) => self.lower_function_expr(ast),
+                E::ForInLoop(ast) => self.lower_for_in_loop(ast),
+                E::Ident(ast) => self.lower_name_ref(&ast.as_string()),
+                E::If(ast) => self.lower_if_expr(ast),
+                E::IntLiteral(ast) => self.lower_int_literal(ast),
+                E::LetBinding(ast) => self.lower_let_binding(ast),
+                E::Loop(ast) => self.lower_loop(ast),
+                E::Paren(ast) => return self.lower_expr(ast.expr()),
+                E::Path(ast) => self.lower_path(ast),
+                E::Return(ast) => self.lower_return_statement(ast),
+                E::StringLiteral(ast) => self.lower_string_literal(ast),
+                E::Unary(ast) => self.lower_unary(ast),
             }
         } else {
             Expr::Empty
@@ -577,19 +577,18 @@ impl Context {
 // Lowering functions - TypeExpr
 impl Context {
     fn lower_type_expr(&mut self, ast: Option<ast::TypeExpr>) -> Idx<TypeExpr> {
-        use ast::TypeExpr::*;
+        use ast::TypeExpr as TE;
         if let Some(ast) = ast {
             let range = ast.range();
             let type_expr = match ast {
-                BoolLiteral(ast) => self.lower_type_bool_literal(ast),
-                FloatLiteral(ast) => self.lower_type_float_literal(ast),
-                IntLiteral(ast) => self.lower_type_int_literal(ast),
-                StringLiteral(ast) => self.lower_type_string_literal(ast),
-
-                Ident(ast) => self.lower_type_ident(ast),
-                Function(_) => todo!(),
-                Path(ast) => self.lower_type_path(ast),
-                Call(ast) => self.lower_type_call(ast),
+                TE::BoolLiteral(ast) => self.lower_type_bool_literal(ast),
+                TE::FloatLiteral(ast) => self.lower_type_float_literal(ast),
+                TE::IntLiteral(ast) => self.lower_type_int_literal(ast),
+                TE::StringLiteral(ast) => self.lower_type_string_literal(ast),
+                TE::Ident(ast) => self.lower_type_ident(ast),
+                TE::Function(_) => todo!(),
+                TE::Path(ast) => self.lower_type_path(ast),
+                TE::Call(ast) => self.lower_type_call(ast),
             };
             self.alloc_type_expr(type_expr, range)
         } else {

--- a/crates/hir/src/tests.rs
+++ b/crates/hir/src/tests.rs
@@ -3,7 +3,7 @@ use lsp_diagnostic::{LSPDiagnostic, LSPDiagnosticSeverity};
 
 use indoc::indoc;
 
-use super::*;
+use crate::{display_root, lower, BlockExpr, Expr, LowerTarget};
 
 macro_rules! cast {
     ($target: expr, $pat: path) => {{
@@ -19,9 +19,11 @@ fn _print(input: &str) {
     let (root_expr, context) = lower(input, LowerTarget::Module);
 
     let root_expr = cast!(context.expr(root_expr), Expr::Block);
-    for expr in root_expr.exprs.iter() {
-        let expr = context.expr(*expr);
-        println!("{expr:?}");
+    if let BlockExpr::NonEmpty { exprs } = root_expr {
+        for expr in exprs {
+            let expr = context.expr(*expr);
+            println!("{expr:?}");
+        }
     }
 }
 

--- a/crates/hir/src/typecheck/infer.rs
+++ b/crates/hir/src/typecheck/infer.rs
@@ -457,17 +457,17 @@ fn infer_binary(expr: &BinaryExpr, context: &mut Context) -> TypeResult {
     let rhs_ty = rhs_result.ty;
     result.chain(rhs_result);
 
-    use BinaryOp::*;
+    use BinaryOp as O;
     match expr.op {
-        Add => infer_binary_add(lhs_ty, rhs_ty, range, context),
-        Concat => infer_binary_concat(lhs_ty, rhs_ty, range, context),
-        Sub => todo!(),
-        Mul => todo!(),
-        Div => todo!(),
-        Rem => todo!(),
-        Exp => todo!(),
-        Path => todo!(),
-        Eq | Ne => infer_binary_equality(lhs_ty, rhs_ty, expr.op, context),
+        O::Add => infer_binary_add(lhs_ty, rhs_ty, range, context),
+        O::Concat => infer_binary_concat(lhs_ty, rhs_ty, range, context),
+        O::Sub => todo!(),
+        O::Mul => todo!(),
+        O::Div => todo!(),
+        O::Rem => todo!(),
+        O::Exp => todo!(),
+        O::Path => todo!(),
+        O::Eq | O::Ne => infer_binary_equality(lhs_ty, rhs_ty, expr.op, context),
     }
 }
 

--- a/crates/js_codegen/src/lib.rs
+++ b/crates/js_codegen/src/lib.rs
@@ -4,7 +4,7 @@ pub fn add(left: usize, right: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::add;
 
     #[test]
     fn it_works() {

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -46,11 +46,14 @@ pub struct Token<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::token_kind::TokenKind::*;
-    use super::*;
+    use text_size::{TextRange, TextSize};
+
+    use crate::{Lexer, Token};
+
+    use super::token_kind::TokenKind as T;
 
     impl<'a> Token<'a> {
-        fn new(kind: TokenKind, text: &'a str, range: TextRange) -> Self {
+        fn new(kind: T, text: &'a str, range: TextRange) -> Self {
             Token { kind, text, range }
         }
     }
@@ -62,10 +65,10 @@ mod tests {
     #[test]
     fn test_basic_operators() {
         let expected = vec![
-            Token::new(Plus, "+", range(0, 1)),
-            Token::new(Dash, "-", range(1, 2)),
-            Token::new(Star, "*", range(2, 3)),
-            Token::new(Slash, "/", range(3, 4)),
+            Token::new(T::Plus, "+", range(0, 1)),
+            Token::new(T::Dash, "-", range(1, 2)),
+            Token::new(T::Star, "*", range(2, 3)),
+            Token::new(T::Slash, "/", range(3, 4)),
         ];
         let lexer = Lexer::new("+-*/");
 

--- a/crates/lexer/src/token_kind.rs
+++ b/crates/lexer/src/token_kind.rs
@@ -319,7 +319,9 @@ impl fmt::Display for TokenKind {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use logos::Logos;
+
+    use crate::TokenKind;
 
     fn check(input: &str, kind: TokenKind) {
         let mut lexer = TokenKind::lexer(input);

--- a/crates/parser/src/parser/parse_error.rs
+++ b/crates/parser/src/parser/parse_error.rs
@@ -42,8 +42,12 @@ impl fmt::Display for ParseError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::ops::Range as StdRange;
+
+    use lexer::TokenKind;
+    use text_size::TextRange;
+
+    use crate::parser::ParseError;
 
     fn check(
         expected: Vec<TokenKind>,

--- a/crates/vm/src/stack.rs
+++ b/crates/vm/src/stack.rs
@@ -406,7 +406,7 @@ impl Default for Stack {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::stack::Stack;
 
     #[test]
     fn push_value() {

--- a/crates/vm_builtins/src/lib.rs
+++ b/crates/vm_builtins/src/lib.rs
@@ -4,7 +4,7 @@ pub fn add(left: usize, right: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::add;
 
     #[test]
     fn it_works() {

--- a/crates/vm_codegen/src/tests.rs
+++ b/crates/vm_codegen/src/tests.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::{codegen, ProgramChunk};
 
 fn generate_chunk(input: &str) -> ProgramChunk {
     let (root, mut context) = hir::lower(input, hir::LowerTarget::Module);

--- a/crates/vm_string/src/tests.rs
+++ b/crates/vm_string/src/tests.rs
@@ -3,7 +3,12 @@ use std::mem;
 use static_assertions::const_assert;
 use vm_types::words::DWORD_SIZE;
 
-use super::*;
+use crate::{
+    as_str::AsStr,
+    embedded::{EmbeddedVMString, MAX_EMBEDDED_LENGTH},
+    heap::HeapVMString,
+    VMString, EMBEDDED_DISCRIMINANT, HEAP_DISCRIMINANT,
+};
 
 const HEAP_STRING: &str = "123456789";
 const_assert!(HEAP_STRING.len() > MAX_EMBEDDED_LENGTH);


### PR DESCRIPTION
Wildcard `use` create maintainability issues, especially in `match` statements. A variant that doesn't exist is treated as a "catch all" pattern rather than a compiler error.