### PR TITLE
[Refactor] Split BlockExpr to Empty/NonEmpty variants

### DIFF
--- a/crates/hir/src/expr/mod.rs
+++ b/crates/hir/src/expr/mod.rs
@@ -38,10 +38,6 @@ pub enum Expr {
     /// result is the evaluation of the final expression.
     Block(BlockExpr),
 
-    /// Empty block expression. Always returns Unit because there
-    /// are no expressions contained within.
-    EmptyBlock,
-
     Call(CallExpr),
 
     VarRef(VarRefExpr),
@@ -166,8 +162,9 @@ pub struct UnaryExpr {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct BlockExpr {
-    pub exprs: Vec<Idx<Expr>>,
+pub enum BlockExpr {
+    Empty,
+    NonEmpty { exprs: Vec<Idx<Expr>> },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -36,7 +36,11 @@ fn lower_module(ast: &ast::Root) -> (Idx<Expr>, Context) {
         .map(|expr| context.lower_expr_statement(Some(expr)))
         .collect();
 
-    let program = Expr::Block(BlockExpr { exprs });
+    let program = if exprs.is_empty() {
+        Expr::Block(BlockExpr::Empty)
+    } else {
+        Expr::Block(BlockExpr::NonEmpty { exprs })
+    };
     let program = context.alloc_expr(program, None);
 
     context.type_check(program, context.type_database.top());


### PR DESCRIPTION
Change the representation of an empty block to be within the BlockExpr rather than another variant of Expr. Simplifies code and better aligns with what the Expr variant model should be.